### PR TITLE
feat: v3.3.0 — transport presets, undo/redo fixes, DX features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,9 @@ coverage/
 .opencode/
 .planning/
 .grepai/
+.claude/
+.claude-flow/
+.swarm/
+.mcp.json
+CLAUDE.md
+docs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 All notable changes to **react-hook-form-autosave** will be documented here.
 
+## [3.3.0] - 2026-04-06
+
+### New Features
+
+- **`fetchTransport(url, options?)`** — Zero-config REST transport preset. Handles JSON serialization, `Content-Type` headers, `AbortSignal` passthrough, and non-2xx error wrapping. Composable with `withRetry()` and `composeTransports()`.
+- **`serverActionTransport(action, options?)`** — Next.js Server Actions transport preset. Calls server actions directly, wraps thrown errors as `TransportError`. Supports `mapPayload` and `mapResult` options.
+- **`useBeforeUnload(shouldBlock)`** — Navigation guard hook that shows a browser confirmation dialog when the user tries to close/reload the tab with unsaved changes.
+- **`onStatusChange` callback** — New option on `useRhfAutosave` that fires on state transitions (`idle` / `saving` / `saved` / `error`). Fires only on transitions, not every render — ideal for toasts, analytics, and error reporting.
+
+### Bug Fixes
+
+- **Undo not activating on first change after hydration** — `handleHydration` and `hydrateFromServer` stored a mutable `form.watch()` reference in `lastValuesRef` without cloning. The first user change mutated both prev and next, so `diffToPatches` saw 0 patches and the undo entry was silently lost. Fixed by cloning values in both hydration paths.
+- **Array values in undo history corrupted by mutation** — `diffToPatches` stored array references directly in patches. Since React Hook Form mutates arrays internally, stored history entries could be corrupted. Fixed by deep-cloning array values when creating patches.
+- **Multi-field undo/redo triggered per-patch validation** — Each `setValue` call during undo/redo triggered independent validation, causing unnecessary work and potential stale-state issues. Fixed by deferring validation (`shouldValidate: false`) and calling `form.trigger()` once after all patches are applied.
+
+### New Exports
+
+```typescript
+// Transport presets
+export { fetchTransport } from "react-hook-form-autosave";
+export type { FetchTransportOptions } from "react-hook-form-autosave";
+export { serverActionTransport } from "react-hook-form-autosave";
+export type { ServerActionTransportOptions } from "react-hook-form-autosave";
+
+// Navigation guard
+export { useBeforeUnload } from "react-hook-form-autosave";
+
+// Status types
+export type { AutosaveStatus } from "react-hook-form-autosave";
+```
+
+### Migration Notes
+
+No breaking changes. All changes are additive. Drop-in replacement for v3.2.0.
+
+---
+
 ## [3.2.0] - 2026-03-19
 
 ### 🧪 Comprehensive Test Coverage & Dependency Upgrades

--- a/README.md
+++ b/README.md
@@ -11,12 +11,17 @@
 ![Demo](https://raw.githubusercontent.com/ziadeh/react-hook-form-autosave/main/assets/demo.gif)
 
 ```tsx
+import { useRhfAutosave, fetchTransport, useBeforeUnload } from "react-hook-form-autosave";
+
 const { isSaving, hasPendingChanges, undo, redo } = useRhfAutosave({
   form,
-  transport: (data) => fetch('/api/save', { method: 'POST', body: JSON.stringify(data) })
+  transport: fetchTransport('/api/save'),
 });
+
+useBeforeUnload(hasPendingChanges);
 ```
 
+✅ **Zero-config transports** - `fetchTransport`, `serverActionTransport` — no boilerplate  
 ✅ **Accurate pending state** - Always know if there are unsaved changes  
 ✅ **Undo/Redo support** - Let users undo mistakes with Cmd/Ctrl+Z  
 ✅ **Array field handling** - Smart diffing for add/remove operations  
@@ -32,6 +37,7 @@ const { isSaving, hasPendingChanges, undo, redo } = useRhfAutosave({
 - [Quick Start](#-quick-start)
 - [Why Choose This?](#-why-choose-this)
 - [Core Features](#-core-features)
+- [Transport Presets](#-transport-presets)
 - [Basic Examples](#-basic-examples)
 - [Common Patterns](#-common-patterns)
 - [Nested Fields](#-nested-fields)
@@ -73,7 +79,7 @@ npm install react@^18 react-dom@^18
 
 ```tsx
 import { useForm } from "react-hook-form";
-import { useRhfAutosave } from "react-hook-form-autosave";
+import { useRhfAutosave, fetchTransport, useBeforeUnload } from "react-hook-form-autosave";
 
 function MyForm() {
   const form = useForm({
@@ -82,29 +88,25 @@ function MyForm() {
 
   const { isSaving, hasPendingChanges } = useRhfAutosave({
     form,
-    transport: async (data) => {
-      const response = await fetch("/api/save", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(data),
-      });
-      return { ok: response.ok };
-    },
+    transport: fetchTransport("/api/save"),
   });
+
+  // Warn before closing tab with unsaved changes
+  useBeforeUnload(hasPendingChanges);
 
   return (
     <form>
       <input {...form.register("name")} placeholder="Name" />
       <input {...form.register("email")} placeholder="Email" />
       <div>
-        {isSaving ? "💾 Saving..." : hasPendingChanges ? "✏️ Editing..." : "✅ Saved"}
+        {isSaving ? "Saving..." : hasPendingChanges ? "Editing..." : "All saved"}
       </div>
     </form>
   );
 }
 ```
 
-**That's it!** Your form now autosaves with accurate pending state tracking.
+**That's it!** Your form now autosaves with accurate pending state tracking and navigation protection.
 
 ---
 
@@ -249,6 +251,93 @@ const { isSaving } = useRhfAutosave({
 // Now when users add/remove tags, only the changes are sent
 // The form properly tracks these as saved after success
 ```
+
+---
+
+## 🚌 Transport Presets
+
+Zero-config transport factories so you never write fetch boilerplate again.
+
+### fetchTransport — REST APIs
+
+```tsx
+import { useRhfAutosave, fetchTransport, withRetry } from "react-hook-form-autosave";
+
+const { isSaving } = useRhfAutosave({
+  form,
+  transport: fetchTransport("/api/save"),
+});
+
+// With options:
+const transport = fetchTransport("/api/save", {
+  method: "PATCH",
+  headers: { Authorization: `Bearer ${token}` },
+  credentials: "include",
+  mapBody: (payload) => ({ data: payload, updatedAt: Date.now() }),
+});
+
+// Compose with retry:
+const reliableTransport = withRetry(
+  fetchTransport("/api/save"),
+  { maxRetries: 3 }
+);
+```
+
+Handles JSON serialization, `Content-Type` headers, `AbortSignal` passthrough, and non-2xx error wrapping automatically.
+
+### serverActionTransport — Next.js Server Actions
+
+```tsx
+// app/actions.ts
+'use server';
+export async function saveForm(data: unknown) {
+  await db.form.update({ data });
+}
+
+// app/components/MyForm.tsx
+import { useRhfAutosave, serverActionTransport } from "react-hook-form-autosave";
+import { saveForm } from "./actions";
+
+const { isSaving } = useRhfAutosave({
+  form,
+  transport: serverActionTransport(saveForm),
+});
+
+// With custom result interpretation:
+const transport = serverActionTransport(saveForm, {
+  mapResult: (result: any) =>
+    result.success ? { ok: true } : { ok: false, error: new Error(result.message) },
+});
+```
+
+Calls the server action directly. Wraps thrown errors as `TransportError`.
+
+### useBeforeUnload — Navigation Guard
+
+```tsx
+import { useRhfAutosave, useBeforeUnload } from "react-hook-form-autosave";
+
+const { hasPendingChanges } = useRhfAutosave({ form, transport });
+
+// Warn before closing tab with unsaved changes
+useBeforeUnload(hasPendingChanges);
+```
+
+### onStatusChange — Lifecycle Callback
+
+```tsx
+const { isSaving } = useRhfAutosave({
+  form,
+  transport,
+  onStatusChange: (status) => {
+    // status.state: 'idle' | 'saving' | 'saved' | 'error'
+    if (status.state === "saved") toast.success("Saved!");
+    if (status.state === "error") Sentry.captureException(status.error);
+  },
+});
+```
+
+Fires on state transitions only, not on every render.
 
 ---
 
@@ -701,6 +790,7 @@ const result = useRhfAutosave<FormData>(options)
 | `shouldSave` | `(ctx) => boolean` | ❌ | Custom save condition |
 | `selectPayload` | `(values, dirty) => Partial<T>` | ❌ | Select fields to save |
 | `onSaved` | `(result, payload) => void` | ❌ | Save callback |
+| `onStatusChange` | `(status: AutosaveStatus) => void` | ❌ | Lifecycle callback (idle/saving/saved/error) |
 | `keyMap` | `KeyMap` | ❌ | Field name mapping |
 | `autoHydrate` | `boolean` | ❌ | Auto-sync server data (default: true) |
 
@@ -771,6 +861,29 @@ function MyForm() {
     </div>
   );
 }
+```
+
+### Next.js + Server Actions
+
+```tsx
+import { serverActionTransport } from "react-hook-form-autosave";
+import { saveFormData } from "./actions"; // Your server action
+
+const { isSaving } = useRhfAutosave({
+  form,
+  transport: serverActionTransport(saveFormData),
+});
+```
+
+### Next.js + REST API
+
+```tsx
+import { fetchTransport } from "react-hook-form-autosave";
+
+const { isSaving } = useRhfAutosave({
+  form,
+  transport: fetchTransport("/api/save"),
+});
 ```
 
 ### Remix
@@ -938,24 +1051,17 @@ const { isSaving } = useRhfAutosave({
 <details>
 <summary><strong>Can I use this with server components?</strong></summary>
 
-This is a client-side hook that requires React Hook Form, so it needs to be used in client components. However, the transport function can call server actions:
+This is a client-side hook that requires React Hook Form, so it needs to be used in client components. Use `serverActionTransport` to call server actions:
 
 ```tsx
 'use client';
 
-import { useRhfAutosave } from 'react-hook-form-autosave';
+import { useRhfAutosave, serverActionTransport } from 'react-hook-form-autosave';
 import { saveFormData } from './actions'; // Server action
 
 const { isSaving } = useRhfAutosave({
   form,
-  transport: async (data) => {
-    try {
-      await saveFormData(data);
-      return { ok: true };
-    } catch (error) {
-      return { ok: false, error };
-    }
-  }
+  transport: serverActionTransport(saveFormData),
 });
 ```
 </details>

--- a/examples/simple-form/actions.ts
+++ b/examples/simple-form/actions.ts
@@ -1,0 +1,16 @@
+"use server";
+
+/**
+ * Example Next.js Server Action for autosave.
+ * In a real app, this would validate input and write to your database.
+ */
+export async function saveProfile(data: unknown) {
+  // Simulate network delay
+  await new Promise((r) => setTimeout(r, 300));
+
+  console.log("Server action received:", data);
+
+  // In production you'd do something like:
+  // const validated = profileSchema.parse(data);
+  // await db.profile.update({ where: { id: userId }, data: validated });
+}

--- a/examples/simple-form/server-action-example.tsx
+++ b/examples/simple-form/server-action-example.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+/**
+ * Example: Using serverActionTransport with Next.js Server Actions
+ *
+ * This shows how to use autosave with a Next.js Server Action instead of
+ * a REST endpoint. The server action handles auth, validation, and DB writes
+ * on the server — the client just passes data through.
+ */
+
+import { useForm } from "react-hook-form";
+import {
+  useRhfAutosave,
+  useBeforeUnload,
+  serverActionTransport,
+} from "react-hook-form-autosave";
+import { saveProfile } from "./actions"; // Your server action
+
+interface ProfileData {
+  name: string;
+  email: string;
+  bio: string;
+}
+
+export default function ServerActionForm() {
+  const form = useForm<ProfileData>({
+    defaultValues: { name: "", email: "", bio: "" },
+  });
+
+  const { isSaving, hasPendingChanges } = useRhfAutosave({
+    form,
+    // One line — calls the server action directly
+    transport: serverActionTransport(saveProfile),
+    config: { debounceMs: 800 },
+    onStatusChange: (status) => {
+      if (status.state === "saved") console.log("Saved!");
+      if (status.state === "error") console.error(status.error);
+    },
+  });
+
+  useBeforeUnload(hasPendingChanges);
+
+  return (
+    <form>
+      <input {...form.register("name")} placeholder="Name" />
+      <input {...form.register("email")} placeholder="Email" />
+      <textarea {...form.register("bio")} placeholder="Bio" />
+      <div>
+        {isSaving
+          ? "Saving..."
+          : hasPendingChanges
+            ? "Unsaved changes"
+            : "All saved"}
+      </div>
+    </form>
+  );
+}

--- a/examples/simple-form/useProfileForm.ts
+++ b/examples/simple-form/useProfileForm.ts
@@ -1,10 +1,15 @@
 "use client";
 
-import { useEffect, useMemo } from "react";
+import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import { useRhfAutosave, type Transport } from "react-hook-form-autosave";
+import {
+  useRhfAutosave,
+  useBeforeUnload,
+  fetchTransport,
+  withRetry,
+} from "react-hook-form-autosave";
 import { useProfileMutation } from "./useProfileMutation";
 
 // Form schema
@@ -26,8 +31,7 @@ export const useProfileForm = ({
   userId,
   initialData,
 }: UseProfileFormProps) => {
-  const { updateProfile, onAddSkill, onRemoveSkill } =
-    useProfileMutation(userId);
+  const { onAddSkill, onRemoveSkill } = useProfileMutation(userId);
 
   const form = useForm<ProfileFormData>({
     resolver: zodResolver(profileSchema),
@@ -41,18 +45,23 @@ export const useProfileForm = ({
     mode: "onChange",
   });
 
-  const transport: Transport = useMemo(() => {
-    return async (payload) => {
-      const { skills: _omit, ...rest } = payload as any;
-      await updateProfile(rest);
-      return { ok: true, version: Date.now().toString() };
-    };
-  }, [updateProfile]);
+  // One-line transport with retry — replaces hand-written fetch wrapper
+  const transport = withRetry(
+    fetchTransport(`/api/profiles/${userId}`, {
+      method: "PATCH",
+      credentials: "include",
+    }),
+    { maxRetries: 2 }
+  );
 
-  const { isSaving, lastError } = useRhfAutosave<ProfileFormData>({
+  const {
+    isSaving,
+    lastError,
+    hasPendingChanges,
+  } = useRhfAutosave<ProfileFormData>({
     form,
     transport,
-    debounceMs: 600,
+    config: { debounceMs: 600 },
     shouldSave: ({ isDirty }) => !!isDirty,
     keyMap: {
       fullName: "full_name",
@@ -66,6 +75,11 @@ export const useProfileForm = ({
         onRemove: onRemoveSkill,
       },
     },
+    onStatusChange: (status) => {
+      if (status.state === "error") {
+        console.error("Autosave failed:", status.error.message);
+      }
+    },
     onSaved: (res) => {
       if (res.ok) {
         form.reset(form.getValues(), { keepValues: true, keepDirty: false });
@@ -73,11 +87,14 @@ export const useProfileForm = ({
     },
   });
 
+  // Warn before closing tab with unsaved changes
+  useBeforeUnload(hasPendingChanges);
+
   useEffect(() => {
     if (initialData) {
       form.reset(initialData, { keepDirty: false });
     }
   }, [initialData, form]);
 
-  return { form, isSaving, lastError };
+  return { form, isSaving, lastError, hasPendingChanges };
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-hook-form-autosave",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "type": "module",
   "description": "Advanced autosave utilities for React Hook Form with debounce, validation, key mapping, diff handling, and comprehensive testing support.",
   "main": "dist/index.cjs",

--- a/src/adapters/rhf/hooks/useUndoRedo.ts
+++ b/src/adapters/rhf/hooks/useUndoRedo.ts
@@ -589,7 +589,7 @@ export function useUndoRedo<T extends FieldValues>(
       // Don't call form.reset() since the form is already in the correct state
       // Just update our internal tracking
       if (undoMgrRef.current) undoMgrRef.current.clear();
-      lastValuesRef.current = data;
+      lastValuesRef.current = cloneValues(data);
       lastRecordedValuesSigRef.current = stableStringify(data as any);
 
       // IMPORTANT: Update baseline and saved state are handled by useAutosaveEffects
@@ -651,7 +651,7 @@ export function useUndoRedo<T extends FieldValues>(
       });
 
       if (undoMgrRef.current) undoMgrRef.current.clear();
-      lastValuesRef.current = data;
+      lastValuesRef.current = cloneValues(data);
       lastRecordedValuesSigRef.current = stableStringify(data as any);
 
       // Update baseline and saved state if provided

--- a/src/adapters/rhf/hooks/useUndoRedo.ts
+++ b/src/adapters/rhf/hooks/useUndoRedo.ts
@@ -155,13 +155,8 @@ export function useUndoRedo<T extends FieldValues>(
       (form as any)?.setValue?.(name, value, {
         shouldDirty: true,
         shouldTouch: true,
-        shouldValidate: true,
+        shouldValidate: false,
       });
-
-      // For arrays, trigger validation after a short delay
-      if (Array.isArray(value)) {
-        setTimeout(() => (form as any)?.trigger?.(name), 0);
-      }
     };
 
     undoMgrRef.current = new InternalUndoManager(
@@ -346,6 +341,11 @@ export function useUndoRedo<T extends FieldValues>(
 
     logger.debug("Execute undo - state after:", undoMgrRef.current.getState());
 
+    // Validate all fields once after all patches applied
+    if (undoSuccessful) {
+      form.trigger();
+    }
+
     if (!undoSuccessful) {
       // Reset state if undo failed
       suppressRecordRef.current = null;
@@ -441,6 +441,11 @@ export function useUndoRedo<T extends FieldValues>(
     const redoSuccessful = undoMgrRef.current.redo();
 
     logger.debug("Execute redo - state after:", undoMgrRef.current.getState());
+
+    // Validate all fields once after all patches applied
+    if (redoSuccessful) {
+      form.trigger();
+    }
 
     if (!redoSuccessful) {
       // Reset state if redo failed

--- a/src/adapters/rhf/managers/__tests__/InternalUndoManager.test.ts
+++ b/src/adapters/rhf/managers/__tests__/InternalUndoManager.test.ts
@@ -433,4 +433,74 @@ describe('InternalUndoManager', () => {
       });
     });
   });
+
+  describe('snapshot before mutate (nested fields)', () => {
+    it('should build redo entry from pre-mutation snapshot for multi-field entries', () => {
+      const values: Record<string, unknown> = { 'profile.firstName': 'Jane', 'profile.lastName': 'Doe' };
+      const setValueCalls: Array<{ name: string; value: unknown }> = [];
+
+      // setValue mutates values immediately (simulating React re-render)
+      const setValue = (name: string, value: unknown) => {
+        values[name] = value;
+        setValueCalls.push({ name, value });
+      };
+      const getCurrentValues = () => ({ ...values });
+      const mgr = new InternalUndoManager(setValue, getCurrentValues);
+
+      // Record: changed both firstName and lastName
+      mgr.record([
+        { name: 'profile.firstName', prevValue: 'John', nextValue: 'Jane', rootField: 'profile' },
+        { name: 'profile.lastName', prevValue: 'Smith', nextValue: 'Doe', rootField: 'profile' },
+      ]);
+
+      // Undo — should snapshot { firstName: 'Jane', lastName: 'Doe' } BEFORE applying
+      mgr.undo();
+
+      // After undo, values should be restored to prev
+      expect(values['profile.firstName']).toBe('John');
+      expect(values['profile.lastName']).toBe('Smith');
+
+      // Now redo — should restore to 'Jane' and 'Doe' (the pre-undo snapshot)
+      setValueCalls.length = 0;
+      mgr.redo();
+
+      const redoFirstName = setValueCalls.find(c => c.name === 'profile.firstName');
+      const redoLastName = setValueCalls.find(c => c.name === 'profile.lastName');
+      expect(redoFirstName?.value).toBe('Jane');
+      expect(redoLastName?.value).toBe('Doe');
+    });
+
+    it('should preserve correct undo values after redo of multi-field entry', () => {
+      const values: Record<string, unknown> = { a: 10, b: 20 };
+      const setValueCalls: Array<{ name: string; value: unknown }> = [];
+
+      const setValue = (name: string, value: unknown) => {
+        values[name] = value;
+        setValueCalls.push({ name, value });
+      };
+      const getCurrentValues = () => ({ ...values });
+      const mgr = new InternalUndoManager(setValue, getCurrentValues);
+
+      mgr.record([
+        { name: 'a', prevValue: 1, nextValue: 10, rootField: 'a' },
+        { name: 'b', prevValue: 2, nextValue: 20, rootField: 'b' },
+      ]);
+
+      // Undo: a→1, b→2
+      mgr.undo();
+      expect(values['a']).toBe(1);
+      expect(values['b']).toBe(2);
+
+      // Redo: a→10, b→20
+      mgr.redo();
+      expect(values['a']).toBe(10);
+      expect(values['b']).toBe(20);
+
+      // Undo again: should go back to a→1, b→2
+      setValueCalls.length = 0;
+      mgr.undo();
+      expect(setValueCalls).toContainEqual({ name: 'a', value: 1 });
+      expect(setValueCalls).toContainEqual({ name: 'b', value: 2 });
+    });
+  });
 });

--- a/src/adapters/rhf/useRhfAutosave.ts
+++ b/src/adapters/rhf/useRhfAutosave.ts
@@ -275,7 +275,7 @@ export function useRhfAutosave<T extends FieldValues>(
     if (!wasSaving && state.isSaving) {
       onStatusChange({ state: 'saving' });
     } else if (wasSaving && !state.isSaving && !state.lastError) {
-      onStatusChange({ state: 'saved', payload: {} });
+      onStatusChange({ state: 'saved' });
     } else if (wasSaving && !state.isSaving && state.lastError) {
       onStatusChange({ state: 'error', error: state.lastError });
     } else if (!wasSaving && !state.isSaving && hadError && !state.lastError) {

--- a/src/adapters/rhf/useRhfAutosave.ts
+++ b/src/adapters/rhf/useRhfAutosave.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useReducer, useMemo, useCallback } from "react";
+import { useEffect, useReducer, useMemo, useCallback, useRef } from "react";
 import type { FieldValues } from "react-hook-form";
 
 import { AutosaveManager } from "../../core/autosave";
@@ -39,6 +39,7 @@ export function useRhfAutosave<T extends FieldValues>(
     selectPayload: userSelectPayload,
     shouldSave: userShouldSave,
     onSaved,
+    onStatusChange,
     keyMap,
     mapPayload,
     validateBeforeSave = "payload",
@@ -258,6 +259,32 @@ export function useRhfAutosave<T extends FieldValues>(
     isSaveResetRef: pendingState.isSaveResetRef,
   });
 
+  // Status change callback — fires on transitions, not every render
+  const prevStatusRef = useRef<{ isSaving: boolean; lastError: Error | null }>({
+    isSaving: false,
+    lastError: null,
+  });
+
+  useEffect(() => {
+    if (!onStatusChange) return;
+
+    const prev = prevStatusRef.current;
+    const wasSaving = prev.isSaving;
+    const hadError = prev.lastError;
+
+    if (!wasSaving && state.isSaving) {
+      onStatusChange({ state: 'saving' });
+    } else if (wasSaving && !state.isSaving && !state.lastError) {
+      onStatusChange({ state: 'saved', payload: {} });
+    } else if (wasSaving && !state.isSaving && state.lastError) {
+      onStatusChange({ state: 'error', error: state.lastError });
+    } else if (!wasSaving && !state.isSaving && hadError && !state.lastError) {
+      onStatusChange({ state: 'idle' });
+    }
+
+    prevStatusRef.current = { isSaving: state.isSaving, lastError: state.lastError };
+  }, [state.isSaving, state.lastError, onStatusChange]);
+
   // Cleanup effect
   useEffect(() => {
     return () => {
@@ -316,4 +343,5 @@ export type {
   DiffHandler,
   UndoOptions,
   AutosaveReturn,
+  AutosaveStatus,
 } from "./utils/types";

--- a/src/adapters/rhf/utils/__tests__/diff.test.ts
+++ b/src/adapters/rhf/utils/__tests__/diff.test.ts
@@ -185,3 +185,32 @@ describe('isEditableElement', () => {
     expect(isEditableElement(div)).toBe(true);
   });
 });
+
+describe('diffToPatches — array cloning', () => {
+  it('should not share references between patch values and input arrays', () => {
+    const prev = { tags: [{ id: 1, name: 'a' }] };
+    const next = { tags: [{ id: 1, name: 'a' }, { id: 2, name: 'b' }] };
+    const patches = diffToPatches(prev, next, '');
+
+    // Mutate the original array
+    next.tags.push({ id: 3, name: 'c' });
+
+    // Patch should NOT reflect the mutation
+    expect(patches[0].nextValue).toHaveLength(2);
+    expect(patches[0].prevValue).toHaveLength(1);
+  });
+
+  it('should clone nested objects within arrays', () => {
+    // Use different array lengths so deepEqual detects a change (id-based comparison ignores content)
+    const prev = { items: [{ id: 1, data: { x: 1 } }] };
+    const next = { items: [{ id: 1, data: { x: 1 } }, { id: 2, data: { x: 2 } }] };
+    const patches = diffToPatches(prev, next, '');
+
+    // Mutate the nested object in the original
+    (next.items[1].data as any).x = 999;
+
+    // Patch should NOT reflect the mutation
+    const patchNext = patches[0].nextValue as any[];
+    expect(patchNext[1].data.x).toBe(2);
+  });
+});

--- a/src/adapters/rhf/utils/diff.ts
+++ b/src/adapters/rhf/utils/diff.ts
@@ -48,6 +48,20 @@ export function deepEqual(a: any, b: any): boolean {
   return false;
 }
 
+function cloneValue(val: any): any {
+  if (val === null || val === undefined) return val;
+  if (val instanceof Date) return new Date(val.getTime());
+  if (Array.isArray(val)) return val.map(cloneValue);
+  if (typeof val === 'object') {
+    const clone: Record<string, any> = {};
+    for (const k of Object.keys(val)) {
+      clone[k] = cloneValue(val[k]);
+    }
+    return clone;
+  }
+  return val;
+}
+
 export function diffToPatches(prev: any, next: any, basePath = ""): Patch[] {
   // Handle nullish values
   if (prev === next) return [];
@@ -62,8 +76,8 @@ export function diffToPatches(prev: any, next: any, basePath = ""): Patch[] {
     return [
       {
         name: basePath,
-        prevValue: prev,
-        nextValue: next,
+        prevValue: cloneValue(prev),
+        nextValue: cloneValue(next),
         rootField: basePath.includes(".") ? basePath.split(".")[0] : basePath,
       },
     ];
@@ -103,8 +117,8 @@ export function diffToPatches(prev: any, next: any, basePath = ""): Patch[] {
         // Arrays are atomic
         patches.push({
           name: childPath,
-          prevValue: p,
-          nextValue: n,
+          prevValue: cloneValue(p),
+          nextValue: cloneValue(n),
           rootField: childPath.includes(".")
             ? childPath.split(".")[0]
             : childPath,

--- a/src/adapters/rhf/utils/types.ts
+++ b/src/adapters/rhf/utils/types.ts
@@ -46,6 +46,14 @@ export interface UndoOptions {
   target?: Document | HTMLElement;
 }
 
+/* ================================ Status Change Types ================================== */
+
+export type AutosaveStatus =
+  | { state: 'idle' }
+  | { state: 'saving' }
+  | { state: 'saved'; payload: SavePayload }
+  | { state: 'error'; error: Error };
+
 /* ================================ Main Hook Options ================================== */
 
 export interface RhfAutosaveOptions<T extends FieldValues> {
@@ -61,6 +69,7 @@ export interface RhfAutosaveOptions<T extends FieldValues> {
     dirtyFields: any;
   }) => boolean;
   onSaved?: (result: any, payload: SavePayload) => void;
+  onStatusChange?: (status: AutosaveStatus) => void;
   keyMap?: KeyMap;
   mapPayload?: (payload: Record<string, any>) => Record<string, any>;
   validateBeforeSave?: ValidationMode;

--- a/src/adapters/rhf/utils/types.ts
+++ b/src/adapters/rhf/utils/types.ts
@@ -51,7 +51,7 @@ export interface UndoOptions {
 export type AutosaveStatus =
   | { state: 'idle' }
   | { state: 'saving' }
-  | { state: 'saved'; payload: SavePayload }
+  | { state: 'saved' }
   | { state: 'error'; error: Error };
 
 /* ================================ Main Hook Options ================================== */

--- a/src/hooks/__tests__/useBeforeUnload.test.ts
+++ b/src/hooks/__tests__/useBeforeUnload.test.ts
@@ -1,0 +1,76 @@
+import { renderHook } from '@testing-library/react';
+import { useBeforeUnload } from '../useBeforeUnload';
+
+describe('useBeforeUnload', () => {
+  let addEventListenerSpy: jest.SpyInstance;
+  let removeEventListenerSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    addEventListenerSpy = jest.spyOn(window, 'addEventListener');
+    removeEventListenerSpy = jest.spyOn(window, 'removeEventListener');
+  });
+
+  afterEach(() => {
+    addEventListenerSpy.mockRestore();
+    removeEventListenerSpy.mockRestore();
+  });
+
+  it('should register beforeunload when shouldBlock is true', () => {
+    renderHook(() => useBeforeUnload(true));
+
+    expect(addEventListenerSpy).toHaveBeenCalledWith(
+      'beforeunload',
+      expect.any(Function)
+    );
+  });
+
+  it('should not register beforeunload when shouldBlock is false', () => {
+    renderHook(() => useBeforeUnload(false));
+
+    expect(addEventListenerSpy).not.toHaveBeenCalledWith(
+      'beforeunload',
+      expect.any(Function)
+    );
+  });
+
+  it('should unregister on unmount', () => {
+    const { unmount } = renderHook(() => useBeforeUnload(true));
+
+    unmount();
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      'beforeunload',
+      expect.any(Function)
+    );
+  });
+
+  it('should unregister when shouldBlock changes to false', () => {
+    const { rerender } = renderHook(
+      ({ block }) => useBeforeUnload(block),
+      { initialProps: { block: true } }
+    );
+
+    rerender({ block: false });
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      'beforeunload',
+      expect.any(Function)
+    );
+  });
+
+  it('should call preventDefault on the beforeunload event', () => {
+    renderHook(() => useBeforeUnload(true));
+
+    const handler = addEventListenerSpy.mock.calls.find(
+      (call: any[]) => call[0] === 'beforeunload'
+    )?.[1];
+
+    const event = new Event('beforeunload', { cancelable: true });
+    Object.defineProperty(event, 'returnValue', { writable: true, value: '' });
+    const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+
+    handler(event);
+
+    expect(preventDefaultSpy).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useBeforeUnload.ts
+++ b/src/hooks/useBeforeUnload.ts
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+
+/**
+ * Shows a browser confirmation dialog when the user tries to close/reload the tab
+ * while there are unsaved changes.
+ */
+export function useBeforeUnload(shouldBlock: boolean): void {
+  useEffect(() => {
+    if (!shouldBlock) return;
+
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+    };
+
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [shouldBlock]);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,10 @@ export { trpcTransport } from "./adapters/trpc/transport";
 export * from "./strategies/validation";
 export * from "./strategies/transport/retry";
 export * from "./strategies/transport/compose";
+export { fetchTransport } from "./strategies/transport/fetch";
+export type { FetchTransportOptions } from "./strategies/transport/fetch";
+export { serverActionTransport } from "./strategies/transport/serverAction";
+export type { ServerActionTransportOptions } from "./strategies/transport/serverAction";
 
 // State management
 export * from "./state/types";
@@ -36,6 +40,12 @@ export { ValidationCache } from "./cache/validationCache";
 export { MetricsCollector, type AutosaveMetrics } from "./metrics/collector";
 
 // Configuration
+
+// Navigation guard
+export { useBeforeUnload } from "./hooks/useBeforeUnload";
+
+// Status types
+export type { AutosaveStatus } from "./adapters/rhf/utils/types";
 
 // Helpers
 export * from "./helpers/pendingChanges";

--- a/src/strategies/transport/__tests__/fetch.test.ts
+++ b/src/strategies/transport/__tests__/fetch.test.ts
@@ -1,0 +1,150 @@
+import { fetchTransport } from '../fetch';
+import { TransportError } from '../../../core/errors';
+import type { SaveContext } from '../../../core/types';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe('fetchTransport', () => {
+  describe('successful saves', () => {
+    it('should POST JSON payload to the given URL', async () => {
+      mockFetch.mockResolvedValue({ ok: true, status: 200 });
+
+      const transport = fetchTransport('/api/save');
+      const result = await transport({ name: 'John', age: 30 });
+
+      expect(result).toEqual({ ok: true });
+      expect(mockFetch).toHaveBeenCalledWith('/api/save', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'same-origin',
+        body: JSON.stringify({ name: 'John', age: 30 }),
+        signal: undefined,
+      });
+    });
+
+    it('should use custom method', async () => {
+      mockFetch.mockResolvedValue({ ok: true, status: 200 });
+
+      const transport = fetchTransport('/api/save', { method: 'PATCH' });
+      await transport({ name: 'John' });
+
+      expect(mockFetch).toHaveBeenCalledWith('/api/save', expect.objectContaining({
+        method: 'PATCH',
+      }));
+    });
+
+    it('should merge custom headers with Content-Type', async () => {
+      mockFetch.mockResolvedValue({ ok: true, status: 200 });
+
+      const transport = fetchTransport('/api/save', {
+        headers: { 'Authorization': 'Bearer token123' },
+      });
+      await transport({ name: 'John' });
+
+      expect(mockFetch).toHaveBeenCalledWith('/api/save', expect.objectContaining({
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer token123',
+        },
+      }));
+    });
+
+    it('should use custom credentials', async () => {
+      mockFetch.mockResolvedValue({ ok: true, status: 200 });
+
+      const transport = fetchTransport('/api/save', { credentials: 'include' });
+      await transport({ name: 'John' });
+
+      expect(mockFetch).toHaveBeenCalledWith('/api/save', expect.objectContaining({
+        credentials: 'include',
+      }));
+    });
+
+    it('should apply mapBody before sending', async () => {
+      mockFetch.mockResolvedValue({ ok: true, status: 200 });
+
+      const transport = fetchTransport('/api/save', {
+        mapBody: (payload) => ({ data: payload, timestamp: 12345 }),
+      });
+      await transport({ name: 'John' });
+
+      expect(mockFetch).toHaveBeenCalledWith('/api/save', expect.objectContaining({
+        body: JSON.stringify({ data: { name: 'John' }, timestamp: 12345 }),
+      }));
+    });
+  });
+
+  describe('error handling', () => {
+    it('should return error for non-2xx response', async () => {
+      mockFetch.mockResolvedValue({ ok: false, status: 400, statusText: 'Bad Request' });
+
+      const transport = fetchTransport('/api/save');
+      const result = await transport({ name: 'John' });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toBeInstanceOf(TransportError);
+        expect(result.error.message).toContain('400');
+      }
+    });
+
+    it('should return error for network failure', async () => {
+      mockFetch.mockRejectedValue(new TypeError('Failed to fetch'));
+
+      const transport = fetchTransport('/api/save');
+      const result = await transport({ name: 'John' });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toBeInstanceOf(TransportError);
+        expect(result.error.message).toContain('Failed to fetch');
+      }
+    });
+
+    it('should handle non-Error thrown values', async () => {
+      mockFetch.mockRejectedValue('string error');
+
+      const transport = fetchTransport('/api/save');
+      const result = await transport({ name: 'John' });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toBeInstanceOf(TransportError);
+      }
+    });
+  });
+
+  describe('abort signal', () => {
+    it('should pass AbortSignal from SaveContext to fetch', async () => {
+      mockFetch.mockResolvedValue({ ok: true, status: 200 });
+
+      const controller = new AbortController();
+      const ctx: SaveContext = { signal: controller.signal };
+
+      const transport = fetchTransport('/api/save');
+      await transport({ name: 'John' }, ctx);
+
+      expect(mockFetch).toHaveBeenCalledWith('/api/save', expect.objectContaining({
+        signal: controller.signal,
+      }));
+    });
+
+    it('should return error when request is aborted', async () => {
+      const abortError = new DOMException('The operation was aborted', 'AbortError');
+      mockFetch.mockRejectedValue(abortError);
+
+      const transport = fetchTransport('/api/save');
+      const result = await transport({ name: 'John' });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toBeInstanceOf(TransportError);
+      }
+    });
+  });
+});

--- a/src/strategies/transport/__tests__/serverAction.test.ts
+++ b/src/strategies/transport/__tests__/serverAction.test.ts
@@ -1,0 +1,106 @@
+import { serverActionTransport } from '../serverAction';
+import { TransportError } from '../../../core/errors';
+
+describe('serverActionTransport', () => {
+  describe('successful saves', () => {
+    it('should call the action with the payload', async () => {
+      const action = jest.fn().mockResolvedValue({ id: 1 });
+
+      const transport = serverActionTransport(action);
+      const result = await transport({ name: 'John' });
+
+      expect(result).toEqual({ ok: true });
+      expect(action).toHaveBeenCalledWith({ name: 'John' });
+    });
+
+    it('should apply mapPayload before calling the action', async () => {
+      const action = jest.fn().mockResolvedValue(undefined);
+
+      const transport = serverActionTransport(action, {
+        mapPayload: (payload) => ({ formData: payload }),
+      });
+      await transport({ name: 'John' });
+
+      expect(action).toHaveBeenCalledWith({ formData: { name: 'John' } });
+    });
+
+    it('should use mapResult to interpret the return value', async () => {
+      const action = jest.fn().mockResolvedValue({ success: false, message: 'Invalid' });
+
+      const transport = serverActionTransport(action, {
+        mapResult: (result: any) =>
+          result.success
+            ? { ok: true as const }
+            : { ok: false as const, error: new Error(result.message) },
+      });
+      const result = await transport({ name: 'John' });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.message).toBe('Invalid');
+      }
+    });
+
+    it('should return ok: true when mapResult returns success', async () => {
+      const action = jest.fn().mockResolvedValue({ success: true });
+
+      const transport = serverActionTransport(action, {
+        mapResult: (result: any) =>
+          result.success ? { ok: true as const } : { ok: false as const, error: new Error('fail') },
+      });
+      const result = await transport({ name: 'John' });
+
+      expect(result).toEqual({ ok: true });
+    });
+  });
+
+  describe('error handling', () => {
+    it('should wrap thrown Error as TransportError', async () => {
+      const action = jest.fn().mockRejectedValue(new Error('Server error'));
+
+      const transport = serverActionTransport(action);
+      const result = await transport({ name: 'John' });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toBeInstanceOf(TransportError);
+        expect(result.error.message).toContain('Server error');
+      }
+    });
+
+    it('should wrap non-Error thrown values', async () => {
+      const action = jest.fn().mockRejectedValue('string error');
+
+      const transport = serverActionTransport(action);
+      const result = await transport({ name: 'John' });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toBeInstanceOf(TransportError);
+        expect(result.error.message).toContain('string error');
+      }
+    });
+
+    it('should handle action returning undefined (void server actions)', async () => {
+      const action = jest.fn().mockResolvedValue(undefined);
+
+      const transport = serverActionTransport(action);
+      const result = await transport({ name: 'John' });
+
+      expect(result).toEqual({ ok: true });
+    });
+  });
+
+  describe('SaveContext', () => {
+    it('should ignore signal (server actions are not cancellable)', async () => {
+      const action = jest.fn().mockResolvedValue(undefined);
+      const controller = new AbortController();
+
+      const transport = serverActionTransport(action);
+      const result = await transport({ name: 'John' }, { signal: controller.signal });
+
+      expect(result).toEqual({ ok: true });
+      expect(action).toHaveBeenCalledWith({ name: 'John' });
+    });
+  });
+});

--- a/src/strategies/transport/fetch.ts
+++ b/src/strategies/transport/fetch.ts
@@ -1,0 +1,63 @@
+import type { Transport, SavePayload, SaveResult, SaveContext } from "../../core/types";
+import { TransportError } from "../../core/errors";
+
+export interface FetchTransportOptions {
+  /** HTTP method. Default: 'POST' */
+  method?: string;
+  /** Extra headers, merged with Content-Type: application/json */
+  headers?: Record<string, string>;
+  /** Fetch credentials mode. Default: 'same-origin' */
+  credentials?: RequestCredentials;
+  /** Transform payload before JSON.stringify */
+  mapBody?: (payload: SavePayload) => unknown;
+}
+
+export function fetchTransport(
+  url: string,
+  options: FetchTransportOptions = {}
+): Transport {
+  const {
+    method = "POST",
+    headers: userHeaders = {},
+    credentials = "same-origin",
+    mapBody,
+  } = options;
+
+  return async (
+    payload: SavePayload,
+    ctx?: SaveContext
+  ): Promise<SaveResult> => {
+    const body = mapBody ? mapBody(payload) : payload;
+
+    try {
+      const response = await fetch(url, {
+        method,
+        headers: {
+          "Content-Type": "application/json",
+          ...userHeaders,
+        },
+        credentials,
+        body: JSON.stringify(body),
+        signal: ctx?.signal,
+      });
+
+      if (!response.ok) {
+        return {
+          ok: false,
+          error: new TransportError(
+            `HTTP ${response.status}: ${response.statusText}`
+          ),
+        };
+      }
+
+      return { ok: true };
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : String(error);
+      return {
+        ok: false,
+        error: new TransportError(message, error instanceof Error ? error : undefined),
+      };
+    }
+  };
+}

--- a/src/strategies/transport/serverAction.ts
+++ b/src/strategies/transport/serverAction.ts
@@ -1,0 +1,40 @@
+import type { Transport, SavePayload, SaveResult, SaveContext } from "../../core/types";
+import { TransportError } from "../../core/errors";
+
+export interface ServerActionTransportOptions {
+  /** Transform payload before calling the action */
+  mapPayload?: (payload: SavePayload) => unknown;
+  /** Interpret the action's return value as a SaveResult */
+  mapResult?: (result: unknown) => SaveResult;
+}
+
+export function serverActionTransport(
+  action: (data: any) => Promise<any>,
+  options: ServerActionTransportOptions = {}
+): Transport {
+  const { mapPayload, mapResult } = options;
+
+  return async (
+    payload: SavePayload,
+    _ctx?: SaveContext
+  ): Promise<SaveResult> => {
+    const data = mapPayload ? mapPayload(payload) : payload;
+
+    try {
+      const result = await action(data);
+
+      if (mapResult) {
+        return mapResult(result);
+      }
+
+      return { ok: true };
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : String(error);
+      return {
+        ok: false,
+        error: new TransportError(message, error instanceof Error ? error : undefined),
+      };
+    }
+  };
+}

--- a/src/strategies/transport/serverAction.ts
+++ b/src/strategies/transport/serverAction.ts
@@ -9,7 +9,7 @@ export interface ServerActionTransportOptions {
 }
 
 export function serverActionTransport(
-  action: (data: any) => Promise<any>,
+  action: (data: unknown) => Promise<unknown>,
   options: ServerActionTransportOptions = {}
 ): Transport {
   const { mapPayload, mapResult } = options;


### PR DESCRIPTION
## Summary

- **`fetchTransport(url, options?)`** — zero-config REST transport, replaces hand-written fetch boilerplate
- **`serverActionTransport(action, options?)`** — Next.js Server Actions transport preset
- **`useBeforeUnload(hasPendingChanges)`** — navigation guard hook
- **`onStatusChange` callback** — fires on idle/saving/saved/error transitions
- **Fix: first-change undo swallowed after hydration** — cloned mutable form.watch() ref in hydration handlers
- **Fix: array undo history corruption** — deep-clone arrays in diffToPatches
- **Fix: batched undo/redo validation** — single form.trigger() after all patches

## Test plan

- [x] 1034 tests pass (27 new)
- [x] Build clean
- [x] Type check passes (0 errors)
- [x] Lint passes (0 new errors)
- [x] Manual browser test: undo activates on first change after page load
- [ ] Smoke test on consuming app after merge